### PR TITLE
feat(legacy): add R1HAL, a slim card-stack-only build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,8 +79,13 @@ jobs:
         #               permission. Mirror-ready for IzzyOnDroid and f-droid.org so
         #               users on those catalogs get a single update path through the
         #               catalog client.
-        # Both share the same applicationId / versionCode / versionName so they
-        # register as the same Android app.
+        # github and fdroid share the same applicationId / versionCode / versionName so
+        # they register as the same Android app.
+        #
+        #   - legacy  → the slim "R1HAL" build. A reduced feature set (card stack + its
+        #               more-info drill-ins only) and a distinct applicationId so it
+        #               installs ALONGSIDE a full R1HA rather than upgrading it. Shipped
+        #               as a separate r1ha-legacy-*.apk artifact below.
         #
         # We build the RELEASE variant rather than debug so R8 minification + resource
         # shrinking apply. The resulting APK is ~5 MB instead of ~70 MB, which keeps
@@ -89,7 +94,7 @@ jobs:
         # local.properties (the case for CI), so the signature stays consistent with
         # the existing user base from prior tag builds — direct-install upgrades work
         # without uninstall.
-        run: ./gradlew :app:assembleGithubRelease :app:assembleFdroidRelease
+        run: ./gradlew :app:assembleGithubRelease :app:assembleFdroidRelease :app:assembleLegacyRelease
 
       - name: Rename APKs
         run: |
@@ -97,6 +102,8 @@ jobs:
              "r1ha-${{ steps.version.outputs.version_name }}.apk"
           mv app/build/outputs/apk/fdroid/release/app-fdroid-release.apk \
              "r1ha-fdroid-${{ steps.version.outputs.version_name }}.apk"
+          mv app/build/outputs/apk/legacy/release/app-legacy-release.apk \
+             "r1ha-legacy-${{ steps.version.outputs.version_name }}.apk"
 
       - name: Generate release notes
         id: notes
@@ -122,3 +129,4 @@ jobs:
           files: |
             r1ha-${{ steps.version.outputs.version_name }}.apk
             r1ha-fdroid-${{ steps.version.outputs.version_name }}.apk
+            r1ha-legacy-${{ steps.version.outputs.version_name }}.apk

--- a/README.md
+++ b/README.md
@@ -138,6 +138,16 @@ The app is built and tested against modern Android (the R1 itself runs Android 1
 
 Nothing in that table blocks the app from installing or running; it is only about which conveniences light up where. The oldest version I have actually tested on is Android 9 (Pie). Anything between the 6.0 floor and there should work but is untested; if you run the app on something older, reports are welcome.
 
+## R1HAL: the slim build
+
+R1HA also ships a deliberately reduced build called **R1HAL**. It keeps the card stack (the heart of the app) and the entity drill-ins reached from a card's more-info sheet (history, logbook, media browsing), and drops everything else: dashboards, energy, automations, scenes, cameras, the voice satellite, the IoT camera and sensor modes, widgets, Quick Settings tiles, and the rest of the management surface. The dropped screens are compiled out, not just hidden. The permissions those features needed (camera, microphone, NFC, Bluetooth, foreground services, write-settings, post-notifications) are stripped from the build too, so R1HAL requests little more than network access (plus install-packages, for its self-updater).
+
+R1HAL is its own app, not a mode you toggle. It has a separate package id, so it installs and runs **alongside** a full R1HA rather than replacing it. It shows up as "R1HAL" in the app drawer with a yellow icon and a yellow accent so the two are never confused.
+
+It runs on the same Android 6.0 floor as the full app. The current Jetpack Compose toolkit hard-requires Android 6.0, so that is genuinely the lowest the card stack can go; R1HAL is about a smaller, single-purpose app rather than a lower OS requirement.
+
+**You may actually prefer R1HAL even on a modern phone.** If all you want is a fast, focused Home Assistant remote built around the card stack, without the dozens of extra screens and the broad permission set the full app carries, the slim build is the leaner, lower-footprint choice. Pick R1HA for the complete tour; pick R1HAL when less is more.
+
 ## Install
 
 Download the latest `r1ha-YYYY.MM.DD.HHmm.apk` from the [Releases](../../releases) page and install it:
@@ -159,7 +169,7 @@ cd R1HA
 adb install app/build/outputs/apk/github/debug/app-github-debug.apk
 ```
 
-There are two product flavors: `github` (includes the in-app self-updater) and `fdroid` (relies on the F-Droid client for updates). Swap `Github` for `Fdroid` in the task name to build the other one.
+There are three product flavors: `github` (includes the in-app self-updater), `fdroid` (relies on the F-Droid client for updates), and `legacy` (the slim "R1HAL" build, see below). Swap `Github` for `Fdroid` or `Legacy` in the task name to build another one.
 
 The local build uses today's date as the version (`YYYYMMDD` for `versionCode`, `YYYY.MM.DD` for `versionName`); CI passes `APP_VERSION_CODE` / `APP_VERSION_NAME` from the release tag.
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -97,30 +97,65 @@ android {
         }
     }
 
-    // Two product flavours so the F-Droid build can omit the in-app self-updater
-    // (and the REQUEST_INSTALL_PACKAGES permission that backs it) without a separate
-    // branch. F-Droid users get updates from the F-Droid client; folding the same
-    // affordance into the github flavour would duplicate notifications and the
-    // permission would be flagged in F-Droid's anti-feature scanner.
+    // Three product flavours so distribution-specific behaviour can vary without a
+    // separate branch:
     //
     //   github  → default; ships to GitHub Releases with self-updater enabled.
-    //   fdroid  → strips the updater UI and drops REQUEST_INSTALL_PACKAGES via a
+    //   fdroid  → strips the in-app self-updater (and REQUEST_INSTALL_PACKAGES) via a
     //             flavour-specific manifest overlay at app/src/fdroid/AndroidManifest.xml.
+    //             F-Droid users get updates from the F-Droid client; folding the same
+    //             affordance in would duplicate notifications and trip F-Droid's
+    //             anti-feature scanner.
+    //   legacy  → a deliberately slim build for aging hardware, branded "R1HAL". Ships
+    //             only the card stack + its more-info drill-ins. minSdk stays at 23
+    //             because the current Jetpack Compose (BOM foundation-layout) hard-floors
+    //             there — 23 is genuinely the lowest API the card stack can run on, so
+    //             the legacy build's value is the reduced feature set + slim APK + its
+    //             own installable package, not a lower OS floor. The reduced set is
+    //             enforced two ways: the
+    //             manifest overlay at app/src/legacy/AndroidManifest.xml drops the
+    //             hardware/service permissions the dropped features needed, and
+    //             AppNavGraph routes the dropped destinations to a placeholder when
+    //             BuildConfig.IS_LEGACY is set. Because IS_LEGACY is a compile-time
+    //             constant, R8 dead-code-eliminates the real feature screens out of the
+    //             release APK entirely (see com.github.itskenny0.r1ha.nav.LegacyFeatures).
+    //             Unlike the other flavours it takes a distinct applicationId (the
+    //             ".legacy" suffix) and its own label / icon / accent so R1HAL installs
+    //             ALONGSIDE a full R1HA rather than upgrading it.
     //
-    // applicationId stays identical across flavours so the two builds register as the
-    // SAME app from Android's POV — switching distribution requires a sign-out then
-    // sign-in only if the signatures differ (they do for f-droid.org's main repo
-    // because F-Droid signs with their own key; they don't for IzzyOnDroid, which
-    // re-publishes the github-flavour APK signed with our key).
+    // github and fdroid keep an identical applicationId so they register as the SAME app
+    // from Android's POV — switching distribution requires a sign-out then sign-in only
+    // if the signatures differ (they do for f-droid.org's main repo because F-Droid signs
+    // with their own key; they don't for IzzyOnDroid, which re-publishes the
+    // github-flavour APK signed with our key).
     flavorDimensions += "distribution"
     productFlavors {
         create("github") {
             dimension = "distribution"
             buildConfigField("boolean", "IS_FDROID_BUILD", "false")
+            buildConfigField("boolean", "IS_LEGACY", "false")
         }
         create("fdroid") {
             dimension = "distribution"
             buildConfigField("boolean", "IS_FDROID_BUILD", "true")
+            buildConfigField("boolean", "IS_LEGACY", "false")
+        }
+        create("legacy") {
+            dimension = "distribution"
+            // Stays at the project floor: the Compose BOM's foundation-layout requires
+            // minSdk 23, so going lower would need tools:overrideLibrary and risk runtime
+            // crashes on exactly the old devices this build targets. 23 is the real floor.
+            minSdk = 23
+            // Distinct package so R1HAL coexists with a full R1HA install. The
+            // FileProvider authority (${applicationId}.updates) and any other
+            // applicationId-derived names follow the suffix automatically.
+            applicationIdSuffix = ".legacy"
+            // Surfaces in the About screen / window title so the slim build is
+            // unmistakable; the launcher label comes from the manifest overlay's
+            // @string/app_name override (R1HAL).
+            versionNameSuffix = "-legacy"
+            buildConfigField("boolean", "IS_FDROID_BUILD", "false")
+            buildConfigField("boolean", "IS_LEGACY", "true")
         }
     }
 

--- a/app/src/legacy/AndroidManifest.xml
+++ b/app/src/legacy/AndroidManifest.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Legacy (R1HAL) flavour overlay. The slim build ships only the card stack and its
+  more-info drill-ins (see com.github.itskenny0.r1ha.nav.LegacyFeatures), so the
+  permissions and background components that the dropped features needed are stripped
+  here via the manifest merger. The self-updater is kept (R1HAL is distributed off
+  GitHub like the github flavour), so REQUEST_INSTALL_PACKAGES, the package-installer
+  query and the FileProvider stay.
+
+  Component names are relative to the namespace package (com.github.itskenny0.r1ha),
+  not the applicationId, so the ".legacy" suffix doesn't change the names below.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <!-- Voice satellite (mic) — dropped. -->
+    <uses-permission android:name="android.permission.RECORD_AUDIO" tools:node="remove"/>
+    <uses-feature android:name="android.hardware.microphone" tools:node="remove"/>
+
+    <!-- IoT Camera Mode — dropped. -->
+    <uses-permission android:name="android.permission.CAMERA" tools:node="remove"/>
+    <uses-feature android:name="android.hardware.camera" tools:node="remove"/>
+    <uses-feature android:name="android.hardware.camera.any" tools:node="remove"/>
+
+    <!-- NFC / tags — dropped. -->
+    <uses-permission android:name="android.permission.NFC" tools:node="remove"/>
+    <uses-feature android:name="android.hardware.nfc" tools:node="remove"/>
+
+    <!-- iBeacon advertiser — dropped. -->
+    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" tools:node="remove"/>
+    <uses-permission android:name="android.permission.BLUETOOTH" tools:node="remove"/>
+    <uses-feature android:name="android.hardware.bluetooth_le" tools:node="remove"/>
+
+    <!-- HA notification mirror — dropped. -->
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" tools:node="remove"/>
+
+    <!-- No foreground services in the slim build (webhook / IoT camera / IoT sensors
+         all dropped), so every FGS permission goes. -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" tools:node="remove"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC" tools:node="remove"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CAMERA" tools:node="remove"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" tools:node="remove"/>
+
+    <!-- IoT Sensors brightness control — dropped. -->
+    <uses-permission android:name="android.permission.WRITE_SETTINGS" tools:node="remove"/>
+
+    <application>
+        <!-- Quick Settings tiles — dropped. -->
+        <service android:name=".feature.quicktile.HaQuickTileService" tools:node="remove"/>
+        <service android:name=".feature.quicktile.HaQuickTileServiceB" tools:node="remove"/>
+        <service android:name=".feature.quicktile.HaQuickTileServiceC" tools:node="remove"/>
+        <service android:name=".feature.quicktile.HaQuickTileServiceD" tools:node="remove"/>
+
+        <!-- IoT Camera / Sensors foreground services + device-admin receiver — dropped. -->
+        <service android:name=".core.iotcamera.IotCameraService" tools:node="remove"/>
+        <service android:name=".core.iotsensors.IotSensorsService" tools:node="remove"/>
+        <receiver android:name=".core.iotsensors.LockAdminReceiver" tools:node="remove"/>
+
+        <!-- Webhook listener + background-refresh job — dropped. -->
+        <service android:name=".core.webhook.WebhookListenerService" tools:node="remove"/>
+        <service android:name=".core.background.BackgroundRefreshJob" tools:node="remove"/>
+
+        <!-- Home-screen widgets — dropped. -->
+        <receiver android:name=".feature.widget.R1haWidgetProvider" tools:node="remove"/>
+        <receiver android:name=".feature.widget.FavoriteCardWidgetProvider" tools:node="remove"/>
+        <activity android:name=".feature.widget.FavoriteCardWidgetConfigActivity" tools:node="remove"/>
+
+        <!-- HA notification-mirror dismiss receiver + external-automation receiver — dropped. -->
+        <receiver
+            android:name=".core.notifications.HaNotificationMirror$DismissActionReceiver"
+            tools:node="remove"/>
+        <receiver android:name=".core.extern.AutomationReceiver" tools:node="remove"/>
+    </application>
+</manifest>

--- a/app/src/legacy/res/drawable/ic_launcher_background.xml
+++ b/app/src/legacy/res/drawable/ic_launcher_background.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Legacy (R1HAL) launcher background. Bright yellow instead of the github/fdroid orange
+  so the slim build is unmistakable in the app drawer when installed alongside a full
+  R1HA, and to match R1HAL's yellow default accent (see R1Dynamic.DEFAULT_ACCENT). This
+  overrides the main drawable of the same name for the legacy flavour only.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp" android:height="108dp"
+    android:viewportWidth="108" android:viewportHeight="108">
+    <path android:pathData="M0,0 H108 V108 H0 Z" android:fillColor="#FFC400"/>
+</vector>

--- a/app/src/legacy/res/values/strings.xml
+++ b/app/src/legacy/res/values/strings.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Launcher label for the slim build. Distinct from R1HA so the two can be told
+         apart in the app drawer when installed side by side. -->
+    <string name="app_name" translatable="false">R1HAL</string>
+</resources>

--- a/app/src/legacy/res/xml/shortcuts.xml
+++ b/app/src/legacy/res/xml/shortcuts.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  No launcher shortcuts on the slim build. The main set targets dropped routes
+  (search / assist / today / automations) and hardcodes the full app's package name,
+  neither of which applies to R1HAL, so the legacy flavour ships an empty set.
+-->
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/app/src/main/kotlin/com/github/itskenny0/r1ha/MainActivity.kt
+++ b/app/src/main/kotlin/com/github/itskenny0/r1ha/MainActivity.kt
@@ -43,6 +43,9 @@ import com.github.itskenny0.r1ha.nav.Routes
  */
 fun resolveStartDestination(settings: AppSettings): String = when {
     settings.server == null -> Routes.ONBOARDING
+    // The Today/Dashboard overview is dropped from the legacy (R1HAL) build, so even a
+    // persisted "start on dashboard" preference resolves to the card stack there.
+    com.github.itskenny0.r1ha.BuildConfig.IS_LEGACY -> Routes.CARD_STACK
     settings.behavior.startOnDashboard &&
         com.github.itskenny0.r1ha.core.prefs.NavItemId.TODAY !in settings.navPanel.hiddenNavItems ->
         Routes.DASHBOARD

--- a/app/src/main/kotlin/com/github/itskenny0/r1ha/core/theme/DynamicTokens.kt
+++ b/app/src/main/kotlin/com/github/itskenny0/r1ha/core/theme/DynamicTokens.kt
@@ -140,11 +140,16 @@ fun namedFontFamily(name: String): FontFamily =
  * old values are discarded. Defaults reproduce today's rendering exactly.
  */
 object R1Dynamic {
-    /** The stock R1 orange — the accent when no override is set. */
-    val DEFAULT_ACCENT = Color(0xFFF36F21)
+    /**
+     * The accent when no override is set: stock R1 orange on the normal builds, and a
+     * bright yellow on the slim legacy build (R1HAL) so the two installs are visually
+     * distinct at a glance and match R1HAL's yellow launcher icon.
+     */
+    val DEFAULT_ACCENT =
+        if (com.github.itskenny0.r1ha.BuildConfig.IS_LEGACY) Color(0xFFFFC400) else Color(0xFFF36F21)
 
     @Volatile
-    var accent: Color = Color(0xFFF36F21)
+    var accent: Color = DEFAULT_ACCENT
 
     @Volatile
     var ramp: R1TypeRamp = buildTypeRamp("")

--- a/app/src/main/kotlin/com/github/itskenny0/r1ha/feature/whatsnew/WhatsNewLogic.kt
+++ b/app/src/main/kotlin/com/github/itskenny0/r1ha/feature/whatsnew/WhatsNewLogic.kt
@@ -49,15 +49,6 @@ fun whatsNewAction(
  * portrait panel.
  */
 val WHATS_NEW_ENTRIES: List<String> = listOf(
-    "Colourful Cards reworked for readability, with palette sets (Vivid, Pastel, Neon) and switchable background designs.",
-    "Colourful Cards now skins scene, script, IR and sensor tiles, so they match the bright cards instead of sitting dark.",
-    "Deck scrolling now reaches every card in turn, last included; it rests flush at the bottom when tall or alone.",
-    "Deck layout adds a Half-height peek mode, and Auto now flows the dynamic layout on phones.",
-    "The value bar clicks under your finger on every card, not only the one the wheel is driving.",
-    "Theme picker redesigned: clearer per-theme previews, selection state, and accent picker.",
-    "Lovelace cards are first-class deck cards: they mix with favourites on any page and look native.",
-    "Broadlink IR/RF console under Settings: guided learn, test-fire, manage; commands live in HA as tagged automations.",
-    "Energy: the draw readout never clips, and the Today power total now matches the energy screen's DRAW.",
-    "Energy view: long-press a top consumer to exclude a mis-reporting sensor from every total; restore from EXCLUDED.",
-    "About: install any GitHub release from a version list; thanks to Home Assistant, Nabu Casa and Open Home Foundation.",
+    "New: R1HAL, a slim companion build centred on the card stack, installable alongside R1HA.",
+    "R1HAL drops the extra screens and most permissions for a leaner, focused Home Assistant remote.",
 )

--- a/app/src/main/kotlin/com/github/itskenny0/r1ha/nav/AppNavGraph.kt
+++ b/app/src/main/kotlin/com/github/itskenny0/r1ha/nav/AppNavGraph.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.getValue
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import com.github.itskenny0.r1ha.BuildConfig
 import com.github.itskenny0.r1ha.core.ha.HaRepository
 import com.github.itskenny0.r1ha.core.input.WheelInput
 import kotlinx.coroutines.flow.first
@@ -141,6 +142,19 @@ fun AppNavGraph(
             else navPopExit
         },
     ) {
+        // Legacy (R1HAL) build: every dropped route resolves to a stub so a stray
+        // affordance or deep link can't crash the NavHost. The full-build branches that
+        // follow register the real screens; R8 strips whichever branch is dead for the
+        // variant being built (BuildConfig.IS_LEGACY is a compile-time constant).
+        if (BuildConfig.IS_LEGACY) {
+            LegacyFeatures.PLACEHOLDER_ROUTES.forEach { route ->
+                composable(route) {
+                    com.github.itskenny0.r1ha.ui.components.LegacyUnavailableScreen(
+                        onBack = { navController.popBackStack() },
+                    )
+                }
+            }
+        }
         composable(Routes.ONBOARDING) {
             OnboardingScreen(
                 settings = settings,
@@ -209,6 +223,9 @@ fun AppNavGraph(
                 onBack = { navController.popBackStack() },
             )
         }
+        // Routes dropped from the legacy (R1HAL) build follow, wrapped so R8 strips the
+        // real screens there; the placeholder block above owns them in legacy.
+        if (!BuildConfig.IS_LEGACY) {
         composable(Routes.SETTINGS_SYNC) {
             com.github.itskenny0.r1ha.feature.settings.SyncSettingsScreen(
                 settings = settings,
@@ -243,6 +260,7 @@ fun AppNavGraph(
                 onBack = { navController.popBackStack() },
             )
         }
+        }
         composable(Routes.THEME_PICKER) {
             ThemePickerScreen(
                 settings = settings,
@@ -276,6 +294,7 @@ fun AppNavGraph(
                 haRepository = haRepository,
             )
         }
+        if (!BuildConfig.IS_LEGACY) {
         composable(Routes.ASSIST) {
             com.github.itskenny0.r1ha.feature.assist.AssistScreen(
                 haRepository = haRepository,
@@ -302,6 +321,7 @@ fun AppNavGraph(
                 wheelInput = wheelInput,
                 onBack = { navController.popBackStack() },
             )
+        }
         }
         composable(Routes.LOGBOOK) {
             com.github.itskenny0.r1ha.feature.logbook.LogbookScreen(
@@ -333,6 +353,7 @@ fun AppNavGraph(
                 initialEntityFilter = backStackEntry.arguments?.getString("entityId"),
             )
         }
+        if (!BuildConfig.IS_LEGACY) {
         composable(Routes.TEMPLATE) {
             com.github.itskenny0.r1ha.feature.template.TemplateScreen(
                 haRepository = haRepository,
@@ -401,6 +422,7 @@ fun AppNavGraph(
                 onBack = { navController.popBackStack() },
             )
         }
+        }
         composable(Routes.LONG_LIVED_TOKEN) {
             com.github.itskenny0.r1ha.feature.longlived.LongLivedTokenScreen(
                 settings = settings,
@@ -421,6 +443,7 @@ fun AppNavGraph(
                 },
             )
         }
+        if (!BuildConfig.IS_LEGACY) {
         composable(Routes.AREAS) {
             com.github.itskenny0.r1ha.feature.areas.AreasScreen(
                 haRepository = haRepository,
@@ -500,6 +523,7 @@ fun AppNavGraph(
                 onBack = { navController.popBackStack() },
             )
         }
+        }
         composable(Routes.MEDIA_BROWSE) {
             com.github.itskenny0.r1ha.feature.mediabrowse.MediaBrowseScreen(
                 haRepository = haRepository,
@@ -520,6 +544,7 @@ fun AppNavGraph(
                 initialEntityId = backStackEntry.arguments?.getString("entityId"),
             )
         }
+        if (!BuildConfig.IS_LEGACY) {
         composable(Routes.BACKUPS) {
             com.github.itskenny0.r1ha.feature.backups.BackupsScreen(
                 haRepository = haRepository,
@@ -558,6 +583,7 @@ fun AppNavGraph(
                 wheelInput = wheelInput,
                 onBack = { navController.popBackStack() },
             )
+        }
         }
         composable(Routes.LOVELACE) {
             com.github.itskenny0.r1ha.feature.lovelace.LovelaceScreen(
@@ -622,6 +648,7 @@ fun AppNavGraph(
                 onBack = { navController.popBackStack() },
             )
         }
+        if (!BuildConfig.IS_LEGACY) {
         composable(Routes.DEVICES) {
             com.github.itskenny0.r1ha.feature.devices.DevicesScreen(
                 haRepository = haRepository,
@@ -638,6 +665,7 @@ fun AppNavGraph(
                 onBack = { navController.popBackStack() },
             )
         }
+        }
         composable(Routes.LOGS) {
             com.github.itskenny0.r1ha.feature.logs.LogsScreen(
                 haRepository = haRepository,
@@ -646,6 +674,7 @@ fun AppNavGraph(
                 onBack = { navController.popBackStack() },
             )
         }
+        if (!BuildConfig.IS_LEGACY) {
         composable(Routes.USERS) {
             com.github.itskenny0.r1ha.feature.users.UsersScreen(
                 haRepository = haRepository,
@@ -818,6 +847,7 @@ fun AppNavGraph(
                     navController.navigate(Routes.historyRoute(entityId)) { launchSingleTop = true }
                 },
             )
+        }
         }
     }
 }

--- a/app/src/main/kotlin/com/github/itskenny0/r1ha/nav/LegacyFeatures.kt
+++ b/app/src/main/kotlin/com/github/itskenny0/r1ha/nav/LegacyFeatures.kt
@@ -1,0 +1,107 @@
+package com.github.itskenny0.r1ha.nav
+
+/**
+ * The keep / drop route partition for the slim "legacy" build (the `legacy` product
+ * flavour, minSdk 21). One source of truth so the nav graph, the pinnable-surface
+ * catalogue and any future affordance gating all agree on what survives.
+ *
+ * The legacy build keeps only the card stack and the surfaces directly reachable from
+ * it or its more-info sheets; everything else is registered to a placeholder so the
+ * real screen is dead-code-eliminated by R8 (BuildConfig.IS_LEGACY is a compile-time
+ * constant — see [AppNavGraph] and app/build.gradle.kts).
+ *
+ * Safety contract enforced by LegacyFeaturesTest: any route an affordance can navigate
+ * to is either in [KEPT_ROUTES] (real screen) or [PLACEHOLDER_ROUTES] (the "not in this
+ * build" stub) — never neither, or the legacy variant would crash on navigate().
+ */
+object LegacyFeatures {
+
+    /**
+     * Routes whose real screen is retained in the legacy build: the shell, the
+     * card-stack favourites flow, settings (with its core categories), and the
+     * more-info drill-ins (history / logbook / media-browse) plus the lightweight
+     * Lovelace / pinned-panel WebViews.
+     */
+    val KEPT_ROUTES: Set<String> = setOf(
+        // Shell + onboarding
+        Routes.ONBOARDING,
+        Routes.CARD_STACK,
+        Routes.CARD_STACK_FOCUS,
+        Routes.FAVORITES_PICKER,
+        // Settings and its standalone sub-screens that aren't device-mode features
+        Routes.SETTINGS,
+        Routes.SETTINGS_KEY_BINDINGS,
+        Routes.SIDEBAR_CONFIG,
+        Routes.THEME_PICKER,
+        Routes.MODIFIED_SETTINGS,
+        Routes.ABOUT,
+        Routes.DEV_MENU,
+        Routes.LONG_LIVED_TOKEN,
+        Routes.DEVICE,
+        // Diagnostics — cheap, and System Health links only to Logs (also kept)
+        Routes.SYSTEM_HEALTH,
+        Routes.LOGS,
+        // more-info drill-ins (the only routes a more-info sheet ever navigates to)
+        Routes.HISTORY,
+        Routes.LOGBOOK,
+        Routes.LOGBOOK_FOR,
+        Routes.MEDIA_BROWSE,
+        Routes.MEDIA_BROWSE_FOR,
+        // Lightweight WebView fallbacks
+        Routes.LOVELACE,
+        Routes.PANEL_VIEWER,
+    )
+
+    /**
+     * Dropped routes that are still registered to a placeholder screen in the legacy
+     * build so any lingering affordance lands on a friendly "not in this build" stub
+     * instead of crashing. No-arg routes only — see LegacyFeaturesTest. Arg-bearing
+     * dropped routes (e.g. DASHBOARDS_VIEW) are reached only from another dropped
+     * screen, so they're never navigated to.
+     */
+    val PLACEHOLDER_ROUTES: List<String> = listOf(
+        // Device-mode settings
+        Routes.SETTINGS_SYNC,
+        Routes.SETTINGS_IOT_CAMERA,
+        Routes.SETTINGS_IOT_SENSORS,
+        Routes.SETTINGS_MQTT,
+        // Voice / assist
+        Routes.ASSIST,
+        Routes.VOICE_SATELLITE,
+        // Standalone feature screens
+        Routes.SCENES,
+        Routes.TEMPLATE,
+        Routes.SERVICE_CALLER,
+        Routes.NOTIFICATIONS,
+        Routes.TODO,
+        Routes.CAMERAS,
+        Routes.WEATHER,
+        Routes.PERSONS,
+        Routes.CALENDARS,
+        Routes.AREAS,
+        Routes.LABELS,
+        Routes.FLOORS,
+        Routes.SERVICES,
+        Routes.SEARCH,
+        Routes.AUTOMATIONS,
+        Routes.HELPERS,
+        Routes.UPDATES,
+        Routes.REPAIRS,
+        Routes.BACKUPS,
+        Routes.ZHA_PAIRING,
+        Routes.BROADLINK,
+        Routes.ENERGY,
+        Routes.ZONES,
+        Routes.DEVICES,
+        Routes.INTEGRATIONS,
+        Routes.USERS,
+        Routes.TAGS,
+        Routes.BLUEPRINTS,
+        Routes.STATISTICS,
+        Routes.DASHBOARDS,
+        Routes.DASHBOARD,
+    )
+
+    /** Is [route]'s real screen retained in the legacy build? */
+    fun isAvailable(route: String?): Boolean = route != null && route in KEPT_ROUTES
+}

--- a/app/src/main/kotlin/com/github/itskenny0/r1ha/nav/PinnableSurfaces.kt
+++ b/app/src/main/kotlin/com/github/itskenny0/r1ha/nav/PinnableSurfaces.kt
@@ -1,6 +1,7 @@
 package com.github.itskenny0.r1ha.nav
 
 import androidx.compose.runtime.Immutable
+import com.github.itskenny0.r1ha.BuildConfig
 
 /**
  * One surface the user is allowed to PIN to the side navigation rail / drawer
@@ -37,7 +38,12 @@ data class PinnableSurface(
  */
 object PinnableSurfaces {
 
-    /** All pinnable surfaces, in offer order. */
+    /**
+     * All pinnable surfaces, in offer order. On the slim legacy build (R1HAL) the
+     * catalogue is filtered to surfaces whose screen survives (see [LegacyFeatures]),
+     * so the drawer never offers a destination that resolves only to the
+     * "not in this build" placeholder.
+     */
     val ALL: List<PinnableSurface> = listOf(
         PinnableSurface(Routes.DASHBOARD, "Today", "◴"),
         PinnableSurface(Routes.DASHBOARDS, "Dashboards", "▤"),
@@ -71,7 +77,9 @@ object PinnableSurfaces {
         PinnableSurface(Routes.SERVICE_CALLER, "Call action", "⎆"),
         PinnableSurface(Routes.TEMPLATE, "Templates", "{}"),
         PinnableSurface(Routes.BACKUPS, "Backups", "⤓"),
-    )
+    ).let { all ->
+        if (BuildConfig.IS_LEGACY) all.filter { LegacyFeatures.isAvailable(it.route) } else all
+    }
 
     private val byRoute: Map<String, PinnableSurface> = ALL.associateBy { it.route }
 

--- a/app/src/main/kotlin/com/github/itskenny0/r1ha/ui/components/LegacyUnavailableScreen.kt
+++ b/app/src/main/kotlin/com/github/itskenny0/r1ha/ui/components/LegacyUnavailableScreen.kt
@@ -1,0 +1,44 @@
+package com.github.itskenny0.r1ha.ui.components
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.github.itskenny0.r1ha.core.theme.R1
+
+/**
+ * Stub destination for routes that the slim "legacy" build (R1HAL) drops. The dropped
+ * feature screens are dead-code-eliminated from that build, so any lingering affordance
+ * that still tries to navigate to one lands here instead of crashing the NavHost. In a
+ * full build this composable is never registered (the IS_LEGACY branch in AppNavGraph
+ * is dead) and R8 strips it.
+ *
+ * The sidebar already filters dropped surfaces out (see PinnableSurfaces /
+ * LegacyFeatures), so in practice this is a safety net for stray Settings-menu rows and
+ * deep links rather than something users routinely hit.
+ */
+@Composable
+fun LegacyUnavailableScreen(onBack: () -> Unit) {
+    BackHandler(onBack = onBack)
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .systemBarsPadding(),
+    ) {
+        Column(Modifier.fillMaxSize()) {
+            R1TopBar(title = "Not in R1HAL", onBack = onBack)
+            R1EmptyState(
+                title = "Not in this build",
+                body = "R1HAL is the slim build. This feature lives in the full R1HA app; " +
+                    "install it alongside R1HAL to use it.",
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(R1.space.l),
+            )
+        }
+    }
+}

--- a/app/src/test/kotlin/com/github/itskenny0/r1ha/MainActivityStartDestinationTest.kt
+++ b/app/src/test/kotlin/com/github/itskenny0/r1ha/MainActivityStartDestinationTest.kt
@@ -24,7 +24,10 @@ class MainActivityStartDestinationTest {
     @Test fun dashboard_when_startOnDashboard_and_today_visible() {
         val s = AppSettings(server = ServerConfig(url = "http://h"))
             .let { it.copy(behavior = it.behavior.copy(startOnDashboard = true)) }
-        assertThat(resolveStartDestination(s)).isEqualTo(Routes.DASHBOARD)
+        // The legacy (R1HAL) build drops the dashboard, so a persisted "start on
+        // dashboard" still lands on the card stack there; the full builds honour it.
+        val expected = if (BuildConfig.IS_LEGACY) Routes.CARD_STACK else Routes.DASHBOARD
+        assertThat(resolveStartDestination(s)).isEqualTo(expected)
     }
 
     @Test fun cardStack_when_startOnDashboard_but_today_hidden() {

--- a/app/src/test/kotlin/com/github/itskenny0/r1ha/nav/LegacyFeaturesTest.kt
+++ b/app/src/test/kotlin/com/github/itskenny0/r1ha/nav/LegacyFeaturesTest.kt
@@ -1,0 +1,66 @@
+package com.github.itskenny0.r1ha.nav
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+/**
+ * Pure-logic coverage for [LegacyFeatures] — the keep / drop route partition that
+ * defines the slim "legacy" build. The invariants here are the safety contract: a
+ * route an affordance navigates to must be either KEPT (real screen) or in
+ * PLACEHOLDER_ROUTES (resolves to the "not in this build" stub), never neither, or
+ * the legacy variant would crash on navigate().
+ */
+class LegacyFeaturesTest {
+
+    @Test fun kept_and_placeholder_sets_are_disjoint() {
+        val overlap = LegacyFeatures.KEPT_ROUTES.intersect(LegacyFeatures.PLACEHOLDER_ROUTES.toSet())
+        assertThat(overlap).isEmpty()
+    }
+
+    @Test fun more_info_drill_ins_are_kept() {
+        // more-info sheets navigate only to history / logbook / media-browse; if any of
+        // these were dropped the card stack's own drill-ins would dangle.
+        assertThat(LegacyFeatures.KEPT_ROUTES).containsAtLeast(
+            Routes.HISTORY,
+            Routes.LOGBOOK,
+            Routes.LOGBOOK_FOR,
+            Routes.MEDIA_BROWSE,
+            Routes.MEDIA_BROWSE_FOR,
+        )
+    }
+
+    @Test fun core_shell_routes_are_kept() {
+        assertThat(LegacyFeatures.KEPT_ROUTES).containsAtLeast(
+            Routes.ONBOARDING,
+            Routes.CARD_STACK,
+            Routes.CARD_STACK_FOCUS,
+            Routes.FAVORITES_PICKER,
+            Routes.SETTINGS,
+        )
+    }
+
+    @Test fun isAvailable_tracks_the_kept_set() {
+        assertThat(LegacyFeatures.isAvailable(Routes.CARD_STACK)).isTrue()
+        assertThat(LegacyFeatures.isAvailable(Routes.ENERGY)).isFalse()
+        assertThat(LegacyFeatures.isAvailable(null)).isFalse()
+    }
+
+    @Test fun every_pinnable_surface_is_registered_in_legacy() {
+        // The sidebar filters to KEPT surfaces, but belt-and-suspenders: every pinnable
+        // route must still resolve (kept or placeholder) so a stale persisted pin can't
+        // navigate to an unregistered destination.
+        val registered = LegacyFeatures.KEPT_ROUTES + LegacyFeatures.PLACEHOLDER_ROUTES
+        PinnableSurfaces.ALL.forEach { surface ->
+            assertThat(registered).contains(surface.route)
+        }
+    }
+
+    @Test fun placeholder_routes_carry_no_path_arguments() {
+        // Placeholders are registered without navArgument specs, so a dropped route that
+        // embeds a `{arg}` segment can't be placeheld this way. Such routes are only ever
+        // reached from another dropped (placeholder) screen, so they're never navigated.
+        LegacyFeatures.PLACEHOLDER_ROUTES.forEach { route ->
+            assertThat(route).doesNotContain("{")
+        }
+    }
+}


### PR DESCRIPTION
Adds R1HAL, a reduced-feature product flavour that installs alongside R1HA under a distinct applicationId (`.legacy` suffix), so it sits next to a full install rather than upgrading it.

What it ships:
- Card stack plus the more-info drill-ins reached from it (history, logbook, media); the rest of the surface is dropped, with dropped routes resolving to a placeholder so R8 strips their real composables via the `IS_LEGACY` compile-time constant.
- A separate `r1ha-legacy-*.apk` artifact with an R1HAL launcher label, yellow icon and yellow default accent so it is unmistakable next to a full install.
- A manifest overlay that strips the permissions and services the dropped features needed.

CI:
- `release.yml` now builds `:app:assembleLegacyRelease`, renames to `r1ha-legacy-<version>.apk`, and attaches it to the GitHub Release alongside the github and fdroid APKs.
- `resolveStartDestination` short-circuits to the card stack under `IS_LEGACY`; the shared start-destination test now asserts the flavour-correct landing screen so the full `test` task is green across github, fdroid and legacy variants.

minSdk stays 23 because the current Jetpack Compose BOM hard-floors there.

Verified locally: `:app:assembleLegacyRelease` builds, and `./gradlew test` is green across all three flavours (debug and release).